### PR TITLE
fix: Remove build ci in lint workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: 'Linting and Building'
+name: 'NextJS lint'
 on:
     push:
         branches: 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,12 +25,7 @@ jobs:
 
       - name: Run lint check
         run: npm run lint
-
-      - name: Build application
-        run: npm run build
-        # env:
-        #   CI: true
-        
+    
         # Ref: https://nextjs.org/docs/pages/building-your-application/deploying/ci-build-caching#github-actions
       - name: Cache node modules
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684


### PR DESCRIPTION
PR ini bertujuan untuk mengurangi waktu tunggu dengan menghilangkan proses building pada proses CI (proses building akan dilakukan ketika akan dihosting)